### PR TITLE
Initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,52 +15,41 @@ Create a temporary fs with JSON fixtures
 ## Example
 
 ```js
-var fixturesFs = require("fixtures-fs");
+var withFixtures = require("fixtures-fs");
+var test = require('tape')
 
-/* withFixtures takes a hash of file fixtures and a task to
-    execute.
+/*
+  this test wants a directory set up with some mock data
+  then do asserts against the directory with some code.
 
-    It then ensures the fixtures exists in the file system,
-        runs the task and then removes the fixtures.
-
-    When it's done with the task it will call the callback.
-
-    ```js
-    var test = require('mocha').test;
-    var assert = require('assert');
-    var configChain = require('config-chain');
-
-    test('run some test', withFixtures(__dirname, {
-        json: {
-            'config.json': '{ "port": 3000, "awesome": true }',
-            'test.json': '{ "port": 4000 }'
-        }
-    }, function (end) {
-        var config = configChain(
-            './json/' + process.env.NODE_ENV + '.json',
-            './json/config.json'
-        );
-
-        assert.equal(config.port, 4000);
-        assert.equal(config.awesome, true);
-
-        end();
-    }));
-    ```
-
-    `withFixtures` is very useful to use with writing integration
-        tests. It allows you to declare a file system as a simple
-        object and then run a test case against it knowing that
-        it will be cleaned up after the test case finishes.
-
-    Notice the usage of the `__dirname` to tell `withFixtures`
-        where the folders are local to. In this case the dirname
-        of the test file, but it can be set to `process.cwd()` or
-        `os.tmpDir()` or whatever location you want.
-
+  withFixtures creates the file system before your test and 
+  tears it down after your test is done.
 */
+test('something something npm', withFixtures(__dirname, {
+  'foo': {
+    'package.json': JSON.stringify({
+      name: 'foo',
+      version: 'bar',
+      dependecies: { 'foobaz': '~1.0.0' }
+    }),
+    'npm-shrinkwrap.json': JSON.stringify({
+      name: 'foo',
+      version: 'bar',
+      dependencies: {
+        'foobaz': {
+          version: '3.0.0',
+          resolved: 'http://npm.registry.org/foobaz/foobaz-3.0.0.tgz'
+        }
+      }
+    })
+  }
+}, function (assert) {
+  myNpmVerify(path.join(__dirname, 'foo'), function (err) {
+    assert.equal(err.message, 'shrinkwrap is wrong.')
 
-// TODO. Show example
+    assert.end()
+  })
+}))
 ```
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Create a temporary fs with JSON fixtures
 ## Example
 
 ```js
-var withFixtures = require("fixtures-fs");
-var test = require("tape")
-var path = require("path")
+var withFixtures = require('fixtures-fs');
+var test = require('tape');
+var path = require('path');
 
 var myNpmVerify = ...
 
@@ -29,17 +29,17 @@ var myNpmVerify = ...
   tears it down after your test is done.
 */
 test('something something npm', withFixtures(__dirname, {
-  'foo': {
+  foo: {
     'package.json': JSON.stringify({
       name: 'foo',
       version: 'bar',
-      dependecies: { 'foobaz': '~1.0.0' }
+      dependecies: { foobaz: '~1.0.0' }
     }),
     'npm-shrinkwrap.json': JSON.stringify({
       name: 'foo',
       version: 'bar',
       dependencies: {
-        'foobaz': {
+        foobaz: {
           version: '3.0.0',
           resolved: 'http://npm.registry.org/foobaz/foobaz-3.0.0.tgz'
         }
@@ -48,35 +48,35 @@ test('something something npm', withFixtures(__dirname, {
   }
 }, function (assert) {
   myNpmVerify(path.join(__dirname, 'foo'), function (err) {
-    assert.equal(err.message, 'shrinkwrap is wrong.')
+    assert.equal(err.message, 'shrinkwrap is wrong.');
 
-    assert.end()
-  })
-}))
+    assert.end();
+  });
+}));
 ```
 
 ### example with mocha
 
 ```js
-var withFixtures = require("fixtures-fs")
-var suite = require("mocha").suite
-var test = require("mocha").it
-var assert = require("assert")
-var path = require("path")
+var withFixtures = require('fixtures-fs');
+var suite = require('mocha').suite;
+var test = require('mocha').it;
+var assert = require('assert');
+var path = require('path');
 
 var myNpmVerify = ...
 
-suite("test npm stuff", function () {
-  test("something something npm", withFixtures(__dirname, {
+suite('test npm stuff', function () {
+  test('something something npm', withFixtures(__dirname, {
     ...
   }, function (end) {
     myNpmVerify(path.join(__dirname, 'foo'), function (err) {
-      assert.equal(err.message, 'shrinkwrap is wrong.')
+      assert.equal(err.message, 'shrinkwrap is wrong.');
 
-      end()
-    })
-  }))
-})
+      end();
+    });
+  }));
+});
 ```
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ suite('test npm stuff', function () {
 
 ## Docs
 
-### `var thunk = withFixtures(dirname, fixtures, lambda, opts={})`
+### `var func = withFixtures(dirname, fixtures, lambda, opts={})`
 
 ```ocaml
 fixtures-fs := (
@@ -99,7 +99,7 @@ It will run create a file system matching your `fixtures`
   before calling your async `lambda` function and tear down
   the file system once the `lambda` finishes.
 
-You can invoke the returned `thunk` with a callback or an object
+You can invoke the returned `func` with a callback or an object
  with an `.end()` method.
 
 #### `dirname`
@@ -143,13 +143,13 @@ You can pass an optional `opts` object to customize the file
   system like a browser file system, a remote file system or
   an in memory file system.
 
-#### `thunk`
+#### `func`
 
-The `thunk` result of the `withFixtures()` call can be passed
+The `func` result of the `withFixtures()` call can be passed
   directly into the `test()` function of `tape` or the `test()`
   function of `mocha`.
 
-When you call `thunk` with either a callback or object with an
+When you call `func` with either a callback or object with an
   `.end()` method argument it will create the fixtures, invoke
   the `lambda`, tear down the fixtures and then invoke either
   the callback or `.end()` method.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can invoke the returned `thunk` with a callback or an object
 
 This is the directory the `fixtures` will be written into.
 
-If this directory does not exist it will be created.
+If this directory does not exist, it will be created.
 
 #### `fixtures`
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,49 @@ Create a temporary fs with JSON fixtures
 ```js
 var fixturesFs = require("fixtures-fs");
 
+/* withFixtures takes a hash of file fixtures and a task to
+    execute.
+
+    It then ensures the fixtures exists in the file system,
+        runs the task and then removes the fixtures.
+
+    When it's done with the task it will call the callback.
+
+    ```js
+    var test = require('mocha').test;
+    var assert = require('assert');
+    var configChain = require('config-chain');
+
+    test('run some test', withFixtures(__dirname, {
+        json: {
+            'config.json': '{ "port": 3000, "awesome": true }',
+            'test.json': '{ "port": 4000 }'
+        }
+    }, function (end) {
+        var config = configChain(
+            './json/' + process.env.NODE_ENV + '.json',
+            './json/config.json'
+        );
+
+        assert.equal(config.port, 4000);
+        assert.equal(config.awesome, true);
+
+        end();
+    }));
+    ```
+
+    `withFixtures` is very useful to use with writing integration
+        tests. It allows you to declare a file system as a simple
+        object and then run a test case against it knowing that
+        it will be cleaned up after the test case finishes.
+
+    Notice the usage of the `__dirname` to tell `withFixtures`
+        where the folders are local to. In this case the dirname
+        of the test file, but it can be set to `process.cwd()` or
+        `os.tmpDir()` or whatever location you want.
+
+*/
+
 // TODO. Show example
 ```
 

--- a/create-fixtures.js
+++ b/create-fixtures.js
@@ -5,6 +5,10 @@ var series = require('continuable-series');
 var globalMkdirp = require('mkdirp');
 var format = require('util').format;
 
+var message = '`fixtures-fs#createFixtures` expected key %s ' +
+    'to have value that is a string or object but we ' +
+    'received %j.';
+
 function createFixtures(dirname, fixtures, opts, callback) {
     if (typeof opts === 'function') {
         callback = opts;
@@ -25,7 +29,7 @@ function createFixtures(dirname, fixtures, opts, callback) {
                 createFixtures.bind(null, loc, value, opts)
             ]);
         } else {
-            var msg = format('value not supported %j', value);
+            var msg = format(message, key, value);
             throw new Error(msg);
         }
     });

--- a/create-fixtures.js
+++ b/create-fixtures.js
@@ -1,0 +1,34 @@
+var globalFs = require('fs');
+var path = require('path');
+var parallel = require('continuable-para');
+var series = require('continuable-series');
+var globalMkdirp = require('mkdirp');
+
+function createFixtures(dirname, fixtures, opts, callback) {
+    if (typeof opts === 'function') {
+        callback = opts;
+        opts = {};
+    }
+
+    var fs = opts.fs || globalFs;
+    var mkdirp = opts.mkdirp || globalMkdirp;
+    var tasks = Object.keys(fixtures).map(function (key) {
+        var value = fixtures[key];
+        var loc = path.join(dirname, key);
+
+        if (typeof value === 'string') {
+            return fs.writeFile.bind(fs, loc, value);
+        } else if (typeof value === 'object') {
+            return series([
+                fs.mkdir.bind(fs, loc),
+                createFixtures.bind(null, loc, value, opts)
+            ]);
+        }
+    });
+
+    tasks.unshift(mkdirp.bind(null, dirname));
+
+    parallel(tasks, callback);
+}
+
+module.exports = createFixtures;

--- a/create-fixtures.js
+++ b/create-fixtures.js
@@ -3,6 +3,7 @@ var path = require('path');
 var parallel = require('continuable-para');
 var series = require('continuable-series');
 var globalMkdirp = require('mkdirp');
+var format = require('util').format;
 
 function createFixtures(dirname, fixtures, opts, callback) {
     if (typeof opts === 'function') {
@@ -23,6 +24,10 @@ function createFixtures(dirname, fixtures, opts, callback) {
                 fs.mkdir.bind(fs, loc),
                 createFixtures.bind(null, loc, value, opts)
             ]);
+        } else {
+            console.log('throwing lol');
+            var msg = format('value not supported %j', value);
+            throw new Error(msg);
         }
     });
 

--- a/create-fixtures.js
+++ b/create-fixtures.js
@@ -25,7 +25,6 @@ function createFixtures(dirname, fixtures, opts, callback) {
                 createFixtures.bind(null, loc, value, opts)
             ]);
         } else {
-            console.log('throwing lol');
             var msg = format('value not supported %j', value);
             throw new Error(msg);
         }

--- a/docs.mli
+++ b/docs.mli
@@ -1,0 +1,13 @@
+
+
+create-fixtures := (
+    dirname: String,
+    fixtures: Object<String, String | Object>,
+    callback: Callback<Error>
+) => void
+
+teardown-fixtures := (
+    dirname: String,
+    fixtures: Object<String, String | Object>,
+    callback: Callback<Error>
+) => void

--- a/docs.mli
+++ b/docs.mli
@@ -1,13 +1,45 @@
+type FsMock := {
+    fs: {
+        writeFile: (String, String, Callback) => void,
+        mkdir: (String, Callback) => void,
+        unlink: (String, Callback) => void
+    },
+    mkdirp: (String, Callback) => void,
+    rimraf: (String, Callback) => void
+}
 
+type Fixture := Object<String, String | Fixture>
 
-create-fixtures := (
+type Task<T> := Callback<Error, T> | Object & {
+    end: Callback<Error, T>
+}
+
+fixtures-fs/create-fixtures := (
     dirname: String,
-    fixtures: Object<String, String | Object>,
+    fixtures: Fixture,
+    opts?: FsMock,
     callback: Callback<Error>
 ) => void
 
-teardown-fixtures := (
+fixtures-fs/teardown-fixtures := (
     dirname: String,
-    fixtures: Object<String, String | Object>,
+    fixtures: Fixture,
+    opts?: FsMock,
     callback: Callback<Error>
 ) => void
+
+fixtures-fs :=
+    (
+        dirname: String,
+        fixtures: Fixture, 
+        lambda: (Task<T>) => void,
+        opts?: FsMock,
+        task: Task<T>
+    ) => void &
+    (
+        dirname: String,
+        fixtures: Fixture, 
+        lambda: (Task<T>) => void,
+        opts?: FsMock
+    ) => (Task<T>) => void
+    

--- a/docs.mli
+++ b/docs.mli
@@ -28,18 +28,9 @@ fixtures-fs/teardown-fixtures := (
     callback: Callback<Error>
 ) => void
 
-fixtures-fs :=
-    (
-        dirname: String,
-        fixtures: Fixture, 
-        lambda: (EndCallback<T>) => void,
-        opts?: FsMock,
-        task: EndCallback<T>
-    ) => void &
-    (
-        dirname: String,
-        fixtures: Fixture, 
-        lambda: (EndCallback<T>) => void,
-        opts?: FsMock
-    ) => (EndCallback<T>) => void
-    
+fixtures-fs := (
+    dirname: String,
+    fixtures: Fixture, 
+    lambda: (EndCallback<T>) => void,
+    opts?: FsMock
+) => (EndCallback<T>) => void

--- a/docs.mli
+++ b/docs.mli
@@ -10,7 +10,7 @@ type FsMock := {
 
 type Fixture := Object<String, String | Fixture>
 
-type Task<T> := Callback<Error, T> | Object & {
+type EndCallback<T> := Callback<Error, T> | Object & {
     end: Callback<Error, T>
 }
 
@@ -32,14 +32,14 @@ fixtures-fs :=
     (
         dirname: String,
         fixtures: Fixture, 
-        lambda: (Task<T>) => void,
+        lambda: (EndCallback<T>) => void,
         opts?: FsMock,
-        task: Task<T>
+        task: EndCallback<T>
     ) => void &
     (
         dirname: String,
         fixtures: Fixture, 
-        lambda: (Task<T>) => void,
+        lambda: (EndCallback<T>) => void,
         opts?: FsMock
-    ) => (Task<T>) => void
+    ) => (EndCallback<T>) => void
     

--- a/index.js
+++ b/index.js
@@ -1,17 +1,5 @@
-/*jshint maxparams: 5 */
 var createFixtures = require('./create-fixtures');
 var teardownFixtures = require('./teardown-fixtures');
-
-/*  to support common testing libraries we accept either a
-    a callback function or an assert like object with an `end()`
-    method on it. 
-*/
-function isTask(maybeTask) {
-    return typeof maybeTask === 'function' || (
-        typeof maybeTask === 'object' && maybeTask !== null &&
-            typeof maybeTask.end === 'function'
-    );
-}
 
 /*   we take the `callback` or object with `.end()` method passed
      to the result of `withFixtures` and intercept such that
@@ -39,27 +27,25 @@ function interceptTask(task, asyncTeardown) {
     }
 }
 
-function withFixtures(dirname, fixtures, lambda, opts, task) {
-    if (isTask(opts)) {
-        task = opts;
-        opts = {};
-    }
+function withFixtures(dirname, fixtures, lambda, opts) {
+    opts = opts || {};
 
-    if (!task) {
-        return withFixtures.bind(null,
-            dirname, fixtures, lambda, opts);
-    }
+    function thunk(task) {
+        function onFixtures(err) {
+            if (err) {
+                return task(err);
+            }
 
-    createFixtures(dirname, fixtures, opts, function onFixtures(err) {
-        if (err) {
-            return task(err);
+            var thunk = teardownFixtures.bind(null,
+                dirname, fixtures, opts);
+
+            lambda(interceptTask(task, thunk));
         }
 
-        var thunk = teardownFixtures.bind(null,
-            dirname, fixtures, opts);
+        createFixtures(dirname, fixtures, opts, onFixtures);
+    }
 
-        lambda(interceptTask(task, thunk));
-    });
+    return thunk;
 }
 
 module.exports = withFixtures;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@
 var createFixtures = require('./create-fixtures');
 var teardownFixtures = require('./teardown-fixtures');
 
+/*  to support common testing libraries we accept either a
+    a callback function or an assert like object with an `end()`
+    method on it. 
+*/
 function isTask(maybeTask) {
     return typeof maybeTask === 'function' || (
         typeof maybeTask === 'object' && maybeTask !== null &&

--- a/index.js
+++ b/index.js
@@ -9,22 +9,27 @@ function isTask(maybeTask) {
     );
 }
 
-function interceptTask(task, thunk) {
-    var callback;
+/*   we take the `callback` or object with `.end()` method passed
+     to the result of `withFixtures` and intercept such that
+     we can apply our async teardown logic before invoking
+     the done callback
+*/
+function interceptTask(task, asyncTeardown) {
+    var doneCallback;
 
     function interceptCallback(err, value) {
         function onTeardown(newErr) {
-            callback(err || newErr, value);
+            doneCallback(err || newErr, value);
         }
 
-        thunk(onTeardown);
+        asyncTeardown(onTeardown);
     }
 
     if (typeof task === 'function') {
-        callback = task;
+        doneCallback = task;
         return interceptCallback;
     } else {
-        callback = task.end.bind(task);
+        doneCallback = task.end.bind(task);
         task.end = interceptCallback;
         return task;
     }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,24 @@
-function fixturesFs() {
-    
+var createFixtures = require('./create-fixtures');
+var teardownFixtures = require('./teardown-fixtures');
+
+function withFixtures(dirname, fixtures, task, callback) {
+    if (!callback) {
+        return withFixtures.bind(null, dirname, fixtures, task);
+    }
+
+    createFixtures(dirname, fixtures, function onFixtures(err) {
+        if (err) {
+            return callback(err);
+        }
+
+        task(function onTask(err, value) {
+            function onTeardown(newErr) {
+                callback(err || newErr, value);
+            }
+
+            teardownFixtures(dirname, fixtures, onTeardown);
+        });
+    });
 }
 
-module.exports = fixturesFs;
+module.exports = withFixtures;

--- a/package.json
+++ b/package.json
@@ -12,19 +12,26 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
+    "continuable-para": "^1.2.0",
+    "continuable-series": "^1.2.0",
+    "mkdirp": "^0.3.5",
+    "rimraf": "^2.2.6"
   },
   "devDependencies": {
-    "tape": "^2.12.3",
-    "jshint": "^2.5.0",
+    "fake-fs": "^0.2.1",
     "istanbul": "^0.2.7",
-    "tap-spec": "^0.1.8",
+    "jshint": "^2.5.0",
     "pre-commit": "0.0.5",
-    "run-browser": "Raynos/run-browser#v1.2.0-phantom"
+    "run-browser": "Raynos/run-browser#v1.2.0-phantom",
+    "tap-spec": "^0.1.8",
+    "tape": "^2.12.3"
   },
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://github.com/uber/fixtures-fs/raw/master/LICENSE"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/uber/fixtures-fs/raw/master/LICENSE"
+    }
+  ],
   "scripts": {
     "test": "npm run jshint --silent && npm run unit-test --silent",
     "unit-test": "NODE_ENV=test node test/index.js | tap-spec",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     }
   ],
   "scripts": {
-    "test": "npm run jshint --silent && npm run unit-test --silent",
-    "unit-test": "NODE_ENV=test node test/index.js | tap-spec",
+    "test": "npm run jshint --silent && NODE_ENV=test node test/index.js | tap-spec",
+    "unit-test": "NODE_ENV=test node test/unit.js | tap-spec",
     "jshint-pre-commit": "jshint --verbose $(git diff --cached --name-only | grep '\\.js$')",
     "jshint": "jshint --verbose .",
     "cover": "istanbul cover --report none --print detail test/index.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "istanbul": "^0.2.7",
     "jshint": "^2.5.0",
     "pre-commit": "0.0.5",
-    "run-browser": "Raynos/run-browser#v1.2.0-phantom",
     "tap-spec": "^0.1.8",
     "tape": "^2.12.3"
   },
@@ -38,9 +37,7 @@
     "jshint-pre-commit": "jshint --verbose $(git diff --cached --name-only | grep '\\.js$')",
     "jshint": "jshint --verbose .",
     "cover": "istanbul cover --report none --print detail test/index.js",
-    "view-cover": "istanbul report html && open ./coverage/index.html",
-    "browser": "run-browser test/index.js",
-    "phantom": "run-browser test/index.js -b"
+    "view-cover": "istanbul report html && open ./coverage/index.html"
   },
   "engine": {
     "node": ">= 0.8.x"

--- a/teardown-fixtures.js
+++ b/teardown-fixtures.js
@@ -1,0 +1,32 @@
+var globalFs = require('fs');
+var path = require('path');
+var parallel = require('continuable-para');
+var series = require('continuable-series');
+var rimraf = require('rimraf');
+
+function teardownFixtures(dirname, fixtures, opts, callback) {
+    if (typeof opts === 'function') {
+        callback = opts;
+        opts = {};
+    }
+
+    var fs = opts.fs || globalFs;
+
+    var tasks = Object.keys(fixtures).map(function (key) {
+        var value = fixtures[key];
+        var loc = path.join(dirname, key);
+
+        if (typeof value === 'string') {
+            return fs.unlink.bind(null, loc);
+        } else if (typeof value === 'object') {
+            return series([
+                teardownFixtures.bind(null, loc, value),
+                rimraf.bind(null, loc)
+            ]);
+        }
+    });
+
+    parallel(tasks, callback);
+}
+
+module.exports = teardownFixtures;

--- a/teardown-fixtures.js
+++ b/teardown-fixtures.js
@@ -3,6 +3,7 @@ var path = require('path');
 var parallel = require('continuable-para');
 var series = require('continuable-series');
 var globalRimRaf = require('rimraf');
+var format = require('util').format;
 
 function teardownFixtures(dirname, fixtures, opts, callback) {
     if (typeof opts === 'function') {
@@ -24,6 +25,9 @@ function teardownFixtures(dirname, fixtures, opts, callback) {
                 teardownFixtures.bind(null, loc, value, opts),
                 rimraf.bind(null, loc)
             ]);
+        } else {
+            var msg = format('value not supported %j', value);
+            throw new Error(msg);
         }
     });
 

--- a/teardown-fixtures.js
+++ b/teardown-fixtures.js
@@ -2,7 +2,7 @@ var globalFs = require('fs');
 var path = require('path');
 var parallel = require('continuable-para');
 var series = require('continuable-series');
-var rimraf = require('rimraf');
+var globalRimRaf = require('rimraf');
 
 function teardownFixtures(dirname, fixtures, opts, callback) {
     if (typeof opts === 'function') {
@@ -11,16 +11,17 @@ function teardownFixtures(dirname, fixtures, opts, callback) {
     }
 
     var fs = opts.fs || globalFs;
+    var rimraf = opts.rimraf || globalRimRaf;
 
     var tasks = Object.keys(fixtures).map(function (key) {
         var value = fixtures[key];
         var loc = path.join(dirname, key);
 
         if (typeof value === 'string') {
-            return fs.unlink.bind(null, loc);
+            return fs.unlink.bind(fs, loc);
         } else if (typeof value === 'object') {
             return series([
-                teardownFixtures.bind(null, loc, value),
+                teardownFixtures.bind(null, loc, value, opts),
                 rimraf.bind(null, loc)
             ]);
         }

--- a/teardown-fixtures.js
+++ b/teardown-fixtures.js
@@ -5,6 +5,10 @@ var series = require('continuable-series');
 var globalRimRaf = require('rimraf');
 var format = require('util').format;
 
+var message = '`fixtures-fs#teardownFixtures` expected key %s ' +
+    'to have value that is a string or object but we ' +
+    'received %j.';
+
 function teardownFixtures(dirname, fixtures, opts, callback) {
     if (typeof opts === 'function') {
         callback = opts;
@@ -26,7 +30,7 @@ function teardownFixtures(dirname, fixtures, opts, callback) {
                 rimraf.bind(null, loc)
             ]);
         } else {
-            var msg = format('value not supported %j', value);
+            var msg = format(message, key, value);
             throw new Error(msg);
         }
     });

--- a/test/create-fixtures.js
+++ b/test/create-fixtures.js
@@ -104,7 +104,7 @@ test('throws on invalid data structures', function (assert) {
         }, fs, function () {
             counter++;
         });
-    }, /value not supported 42/);
+    }, /we received 42/);
 
     assert.equal(counter, 0);
 

--- a/test/create-fixtures.js
+++ b/test/create-fixtures.js
@@ -1,0 +1,74 @@
+var test = require('tape');
+var FakeFs = require('fake-fs');
+var path = require('path');
+
+var createFixtures = require('../create-fixtures.js');
+
+var FOO_PATH = path.join(__dirname, 'foo');
+var BAR_PATH = path.join(__dirname, 'bar');
+var BAZ_PATH = path.join(__dirname, 'bar', 'baz');
+
+function createFs() {
+    var fs = new FakeFs();
+    fs.mkdirp = function (dirname, cb) {
+        fs.dir(dirname);
+        process.nextTick(cb);
+    };
+    return fs;
+}
+
+test('createFixtures is a function', function (assert) {
+    assert.equal(typeof createFixtures, 'function');
+
+    assert.end();
+});
+
+test('create single file', function (assert) {
+    var fs = createFs();
+
+    createFixtures(__dirname, {
+        'foo': 'bar'
+    }, { fs: fs, mkdirp: fs.mkdirp }, function (err) {
+        assert.ifError(err);
+
+        assert.equal(fs.readFileSync(FOO_PATH, 'utf8'), 'bar');
+
+        assert.end();
+    });
+});
+
+test('create multiple files', function (assert) {
+    var fs = createFs();
+
+    createFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': 'baz'
+    }, { fs: fs, mkdirp: fs.mkdirp }, function (err) {
+        assert.ifError(err);
+
+        assert.equal(fs.readFileSync(FOO_PATH, 'utf8'), 'bar');
+        assert.equal(fs.readFileSync(BAR_PATH, 'utf8'), 'baz');
+
+        assert.end();
+    });
+});
+
+test('create folders', function (assert) {
+    var fs = createFs();
+
+    createFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, { fs: fs, mkdirp: fs.mkdirp }, function (err) {
+        assert.ifError(err);
+
+        assert.equal(fs.readFileSync(FOO_PATH, 'utf8'), 'bar');
+        assert.equal(fs.statSync(BAR_PATH).isDirectory(), true);
+        assert.equal(fs.readFileSync(BAZ_PATH, 'utf8'), 'foobar');
+
+        assert.end();
+    });
+});
+

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,2 @@
-require('./create-fixtures.js');
-require('./with-fixtures.js');
+require('./unit.js');
+require('./integration.js');

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,2 @@
-var test = require('tape');
-
-var fixturesFs = require('../index.js');
-
-test('fixturesFs is a function', function (assert) {
-    assert.strictEqual(typeof fixturesFs, 'function');
-    assert.end();
-});
+require('./create-fixtures.js');
+require('./with-fixtures.js');

--- a/test/integration.js
+++ b/test/integration.js
@@ -27,7 +27,7 @@ test('create temporary file system', function (assert) {
         assert.equal(fs.existsSync(BAZ_PATH), true);
 
         process.nextTick(callback);
-    }, function (err) {
+    })(function (err) {
         assert.ifError(err);
 
         assert.equal(fs.existsSync(FOO_PATH), false);

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,0 +1,84 @@
+var test = require('tape');
+var path = require('path');
+var fs = require('fs');
+var rimraf = require('rimraf');
+
+var withFixtures = require('../index.js');
+var createFixtures = require('../create-fixtures.js');
+var teardownFixtures = require('../teardown-fixtures.js');
+
+var FOO_PATH = path.join(__dirname, 'foo');
+var BAR_PATH = path.join(__dirname, 'bar');
+var BAZ_PATH = path.join(__dirname, 'bar', 'baz');
+
+test('create temporary file system', function (assert) {
+    assert.equal(fs.existsSync(FOO_PATH), false);
+    assert.equal(fs.existsSync(BAR_PATH), false);
+    assert.equal(fs.existsSync(BAZ_PATH), false);
+
+    withFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (callback) {
+        assert.equal(fs.existsSync(FOO_PATH), true);
+        assert.equal(fs.existsSync(BAR_PATH), true);
+        assert.equal(fs.existsSync(BAZ_PATH), true);
+
+        process.nextTick(callback);
+    }, function (err) {
+        assert.ifError(err);
+
+        assert.equal(fs.existsSync(FOO_PATH), false);
+        assert.equal(fs.existsSync(BAR_PATH), false);
+        assert.equal(fs.existsSync(BAZ_PATH), false);
+
+        assert.end();
+    });
+});
+
+test('create folders', function (assert) {
+    createFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (err) {
+        assert.ifError(err);
+
+        assert.equal(fs.readFileSync(FOO_PATH, 'utf8'), 'bar');
+        assert.equal(fs.statSync(BAR_PATH).isDirectory(), true);
+        assert.equal(fs.readFileSync(BAZ_PATH, 'utf8'), 'foobar');
+
+        rimraf.sync(FOO_PATH);
+        rimraf.sync(BAR_PATH);
+
+        assert.end();
+    });
+});
+
+test('removes folders', function (assert) {
+    fs.writeFileSync(FOO_PATH, 'bar', 'utf8');
+    fs.mkdirSync(BAR_PATH);
+    fs.writeFileSync(BAZ_PATH, 'foobar', 'utf8');
+
+    assert.equal(fs.existsSync(FOO_PATH), true);
+    assert.equal(fs.existsSync(BAR_PATH), true);
+    assert.equal(fs.existsSync(BAZ_PATH), true);
+
+    teardownFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (err) {
+        assert.ifError(err);
+
+        assert.equal(fs.existsSync(FOO_PATH), false);
+        assert.equal(fs.existsSync(BAR_PATH), false);
+        assert.equal(fs.existsSync(BAZ_PATH), false);
+
+        assert.end();
+    });
+});

--- a/test/teardown-fixtures.js
+++ b/test/teardown-fixtures.js
@@ -24,6 +24,7 @@ function createFs() {
 
         process.nextTick(cb);
     };
+    fs.fs = fs;
     return fs;
 }
 
@@ -41,7 +42,7 @@ test('removes single file', function (assert) {
 
     teardownFixtures(__dirname, {
         'foo': 'bar'
-    }, { fs: fs, rimraf: fs.rimraf }, function (err) {
+    }, fs, function (err) {
         assert.ifError(err);
 
         assert.equal(fs.existsSync(FOO_PATH), false);
@@ -61,7 +62,7 @@ test('removes multiple files', function (assert) {
     teardownFixtures(__dirname, {
         'foo': 'bar',
         'bar': 'baz'
-    }, { fs: fs, rimraf: fs.rimraf }, function (err) {
+    }, fs, function (err) {
         assert.ifError(err);
 
         assert.equal(fs.existsSync(FOO_PATH), false);
@@ -85,7 +86,7 @@ test('removes folders', function (assert) {
         'bar': {
             'baz': 'foobar'
         }
-    }, { fs: fs, rimraf: fs.rimraf }, function (err) {
+    }, fs, function (err) {
         assert.ifError(err);
 
         assert.equal(fs.existsSync(FOO_PATH), false);
@@ -112,7 +113,7 @@ test('cleanups other files', function (assert) {
         'bar': {
             'baz': 'foobar'
         }
-    }, { fs: fs, rimraf: fs.rimraf }, function (err) {
+    }, fs, function (err) {
         assert.ifError(err);
 
         assert.equal(fs.existsSync(FOO_PATH), false);
@@ -122,4 +123,41 @@ test('cleanups other files', function (assert) {
 
         assert.end();
     });
+});
+
+test('errors if file does not exist', function (assert) {
+    var fs = createFs();
+    fs.file(BAZ_PATH, 'foobar');
+    fs.file(GIT_PATH, 'some git stuff');
+
+    teardownFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, fs, function (err) {
+        assert.ok(err);
+
+        assert.equal(err.code, 'ENOENT');
+
+        assert.end();
+    });
+});
+
+
+test('throws on invalid data structures', function (assert) {
+    var fs = createFs();
+    var counter = 0;
+
+    assert.throws(function () {
+        teardownFixtures(__dirname, {
+            foo: 42
+        }, fs, function () {
+            counter++;
+        });
+    }, /value not supported 42/);
+
+    assert.equal(counter, 0);
+
+    assert.end();
 });

--- a/test/teardown-fixtures.js
+++ b/test/teardown-fixtures.js
@@ -1,0 +1,125 @@
+var test = require('tape');
+var FakeFs = require('fake-fs');
+var path = require('path');
+
+var teardownFixtures = require('../teardown-fixtures.js');
+
+var FOO_PATH = path.join(__dirname, 'foo');
+var BAR_PATH = path.join(__dirname, 'bar');
+var BAZ_PATH = path.join(__dirname, 'bar', 'baz');
+var GIT_PATH = path.join(__dirname, 'bar', '.git');
+
+function createFs() {
+    var fs = new FakeFs();
+    fs.rimraf = function (loc, cb) {
+        var dirname = path.dirname(loc);
+        var fileName = path.basename(loc);
+        var item = fs._itemAt(dirname);
+
+        if (!item) {
+            return process.nextTick(cb);
+        }
+
+        delete item.childs[fileName];
+
+        process.nextTick(cb);
+    };
+    return fs;
+}
+
+test('teardownFixtures is a function', function (assert) {
+    assert.equal(typeof teardownFixtures, 'function');
+
+    assert.end();
+});
+
+test('removes single file', function (assert) {
+    var fs = createFs();
+    fs.file(FOO_PATH, 'bar');
+
+    assert.equal(fs.existsSync(FOO_PATH), true);
+
+    teardownFixtures(__dirname, {
+        'foo': 'bar'
+    }, { fs: fs, rimraf: fs.rimraf }, function (err) {
+        assert.ifError(err);
+
+        assert.equal(fs.existsSync(FOO_PATH), false);
+
+        assert.end();
+    });
+});
+
+test('removes multiple files', function (assert) {
+    var fs = createFs();
+    fs.file(FOO_PATH, 'bar');
+    fs.file(BAR_PATH, 'baz');
+
+    assert.equal(fs.existsSync(FOO_PATH), true);
+    assert.equal(fs.existsSync(BAR_PATH), true);
+
+    teardownFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': 'baz'
+    }, { fs: fs, rimraf: fs.rimraf }, function (err) {
+        assert.ifError(err);
+
+        assert.equal(fs.existsSync(FOO_PATH), false);
+        assert.equal(fs.existsSync(BAR_PATH), false);
+
+        assert.end();
+    });
+});
+
+test('removes folders', function (assert) {
+    var fs = createFs();
+    fs.file(FOO_PATH, 'bar');
+    fs.file(BAZ_PATH, 'foobar');
+
+    assert.equal(fs.existsSync(FOO_PATH), true);
+    assert.equal(fs.existsSync(BAR_PATH), true);
+    assert.equal(fs.existsSync(BAZ_PATH), true);
+
+    teardownFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, { fs: fs, rimraf: fs.rimraf }, function (err) {
+        assert.ifError(err);
+
+        assert.equal(fs.existsSync(FOO_PATH), false);
+        assert.equal(fs.existsSync(BAR_PATH), false);
+        assert.equal(fs.existsSync(BAZ_PATH), false);
+
+        assert.end();
+    });
+});
+
+test('cleanups other files', function (assert) {
+    var fs = createFs();
+    fs.file(FOO_PATH, 'bar');
+    fs.file(BAZ_PATH, 'foobar');
+    fs.file(GIT_PATH, 'some git stuff');
+
+    assert.equal(fs.existsSync(FOO_PATH), true);
+    assert.equal(fs.existsSync(BAR_PATH), true);
+    assert.equal(fs.existsSync(BAZ_PATH), true);
+    assert.equal(fs.existsSync(GIT_PATH), true);
+
+    teardownFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, { fs: fs, rimraf: fs.rimraf }, function (err) {
+        assert.ifError(err);
+
+        assert.equal(fs.existsSync(FOO_PATH), false);
+        assert.equal(fs.existsSync(BAR_PATH), false);
+        assert.equal(fs.existsSync(BAZ_PATH), false);
+        assert.equal(fs.existsSync(GIT_PATH), false);
+
+        assert.end();
+    });
+});

--- a/test/teardown-fixtures.js
+++ b/test/teardown-fixtures.js
@@ -155,7 +155,7 @@ test('throws on invalid data structures', function (assert) {
         }, fs, function () {
             counter++;
         });
-    }, /value not supported 42/);
+    }, /we received 42/);
 
     assert.equal(counter, 0);
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,0 +1,3 @@
+require('./create-fixtures.js');
+require('./teardown-fixtures.js');
+require('./with-fixtures.js');

--- a/test/with-fixtures.js
+++ b/test/with-fixtures.js
@@ -1,0 +1,8 @@
+var test = require('tape');
+
+var withFixtures = require('../index.js');
+
+test('withFixtures is a function', function (assert) {
+    assert.strictEqual(typeof withFixtures, 'function');
+    assert.end();
+});

--- a/test/with-fixtures.js
+++ b/test/with-fixtures.js
@@ -1,8 +1,241 @@
 var test = require('tape');
+var FakeFs = require('fake-fs');
+var path = require('path');
 
 var withFixtures = require('../index.js');
+
+var FOO_PATH = path.join(__dirname, 'foo');
+var BAR_PATH = path.join(__dirname, 'bar');
+var BAZ_PATH = path.join(__dirname, 'bar', 'baz');
+
+function createFs() {
+    var fs = new FakeFs();
+    fs.mkdirp = function (dirname, cb) {
+        if (!fs.existsSync(dirname)) {
+            fs.dir(dirname);
+        }
+        process.nextTick(cb);
+    };
+    fs.rimraf = function (loc, cb) {
+        var dirname = path.dirname(loc);
+        var fileName = path.basename(loc);
+        var item = fs._itemAt(dirname);
+
+        if (!item) {
+            return process.nextTick(cb);
+        }
+
+        delete item.childs[fileName];
+
+        process.nextTick(cb);
+    };
+    fs.fs = fs;
+    return fs;
+}
 
 test('withFixtures is a function', function (assert) {
     assert.strictEqual(typeof withFixtures, 'function');
     assert.end();
+});
+
+test('create temporary file system', function (assert) {
+    var fs = createFs();
+
+    assert.equal(fs.existsSync(FOO_PATH), false);
+    assert.equal(fs.existsSync(BAR_PATH), false);
+    assert.equal(fs.existsSync(BAZ_PATH), false);
+
+    withFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (callback) {
+        assert.equal(fs.existsSync(FOO_PATH), true);
+        assert.equal(fs.existsSync(BAR_PATH), true);
+        assert.equal(fs.existsSync(BAZ_PATH), true);
+
+        process.nextTick(callback);
+    }, fs, function (err) {
+        assert.ifError(err);
+
+        assert.equal(fs.existsSync(FOO_PATH), false);
+        assert.equal(fs.existsSync(BAR_PATH), false);
+        assert.equal(fs.existsSync(BAZ_PATH), false);
+
+        assert.end();
+    });
+});
+
+test('createFixtures errors bubbles', function (assert) {
+    var fs = createFs();
+    var counter = 0;
+
+    fs.dir(BAR_PATH);
+
+    withFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (callback) {
+        counter++;
+
+        process.nextTick(callback);
+    }, fs, function (err) {
+        assert.ok(err);
+
+        assert.equal(counter, 0);
+        assert.equal(err.code, 'EEXIST');
+
+        assert.end();
+    });
+});
+
+test('teardownFixtures errors bubbles', function (assert) {
+    var fs = createFs();
+
+    withFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (callback) {
+        fs.unlinkSync(FOO_PATH);
+
+        process.nextTick(callback);
+    }, fs, function (err) {
+        assert.ok(err);
+
+        assert.equal(err.code, 'ENOENT');
+
+        assert.end();
+    });
+});
+
+test('task errors bubble', function (assert) {
+    var fs = createFs();
+
+    withFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (callback) {
+        assert.equal(fs.existsSync(FOO_PATH), true);
+        assert.equal(fs.existsSync(BAR_PATH), true);
+        assert.equal(fs.existsSync(BAZ_PATH), true);
+
+        process.nextTick(callback.bind(null, new Error('foo')));
+    }, fs, function (err) {
+        assert.ok(err);
+
+        assert.equal(err.message, 'foo');
+
+        assert.equal(fs.existsSync(FOO_PATH), false);
+        assert.equal(fs.existsSync(BAR_PATH), false);
+        assert.equal(fs.existsSync(BAZ_PATH), false);
+
+        assert.end();
+    });
+});
+
+test('task can be assert.end interface (thunk)', function (assert) {
+    var fs = createFs();
+
+    var assertLike = {
+        end: function (err, value) {
+            assert.ifError(err);
+
+            assert.equal(value, 42);
+
+            assert.end();
+        },
+        equal: function () {}
+    };
+
+    var thunk = withFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (assertLike) {
+        assert.equal(typeof assertLike.equal, 'function');
+        assert.equal(typeof assertLike.end, 'function');
+        assert.equal(typeof assertLike, 'object');
+
+        process.nextTick(assertLike.end.bind(null, null, 42));
+    }, fs);
+
+    thunk(assertLike);
+});
+
+test('task can be assert.end interface', function (assert) {
+    var fs = createFs();
+
+    var assertLike = {
+        end: function (err, value) {
+            assert.ifError(err);
+
+            assert.equal(value, 42);
+
+            assert.end();
+        },
+        equal: function () {}
+    };
+
+    withFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (assertLike) {
+        assert.equal(typeof assertLike.equal, 'function');
+        assert.equal(typeof assertLike.end, 'function');
+        assert.equal(typeof assertLike, 'object');
+
+        process.nextTick(assertLike.end.bind(null, null, 42));
+    }, fs, assertLike);
+});
+
+test('can pass through values', function (assert) {
+    var fs = createFs();
+
+    withFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (callback) {
+        process.nextTick(callback.bind(null, null, 42));
+    }, fs, function (err, value) {
+        assert.ifError(err);
+
+        assert.equal(value, 42);
+
+        assert.end();
+    });
+});
+
+test('withFixtures returns thunks', function (assert) {
+    var fs = createFs();
+
+    var thunk = withFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (callback) {
+        process.nextTick(callback.bind(null, null, 42));
+    }, fs);
+
+    assert.equal(typeof thunk, 'function');
+
+    thunk(function (err, value) {
+        assert.ifError(err);
+
+        assert.equal(value, 42);
+
+        assert.end();
+    });
 });

--- a/test/with-fixtures.js
+++ b/test/with-fixtures.js
@@ -56,7 +56,7 @@ test('create temporary file system', function (assert) {
         assert.equal(fs.existsSync(BAZ_PATH), true);
 
         process.nextTick(callback);
-    }, fs, function (err) {
+    }, fs)(function (err) {
         assert.ifError(err);
 
         assert.equal(fs.existsSync(FOO_PATH), false);
@@ -82,7 +82,7 @@ test('createFixtures errors bubbles', function (assert) {
         counter++;
 
         process.nextTick(callback);
-    }, fs, function (err) {
+    }, fs)(function (err) {
         assert.ok(err);
 
         assert.equal(counter, 0);
@@ -104,7 +104,7 @@ test('teardownFixtures errors bubbles', function (assert) {
         fs.unlinkSync(FOO_PATH);
 
         process.nextTick(callback);
-    }, fs, function (err) {
+    }, fs)(function (err) {
         assert.ok(err);
 
         assert.equal(err.code, 'ENOENT');
@@ -127,7 +127,7 @@ test('task errors bubble', function (assert) {
         assert.equal(fs.existsSync(BAZ_PATH), true);
 
         process.nextTick(callback.bind(null, new Error('foo')));
-    }, fs, function (err) {
+    }, fs)(function (err) {
         assert.ok(err);
 
         assert.equal(err.message, 'foo');
@@ -195,7 +195,7 @@ test('task can be assert.end interface', function (assert) {
         assert.equal(typeof assertLike, 'object');
 
         process.nextTick(assertLike.end.bind(null, null, 42));
-    }, fs, assertLike);
+    }, fs)(assertLike);
 });
 
 test('can pass through values', function (assert) {
@@ -208,7 +208,7 @@ test('can pass through values', function (assert) {
         }
     }, function (callback) {
         process.nextTick(callback.bind(null, null, 42));
-    }, fs, function (err, value) {
+    }, fs)(function (err, value) {
         assert.ifError(err);
 
         assert.equal(value, 42);


### PR DESCRIPTION
This module serves two purposes
- I'm going to make 100% compat with play-doh open source standards. Thus setting an example for other modules
- it fixes a painpoint writing tests for CLIs that work with files, git & npm.

The tests run and have 100% branch coverage.

cc @sh1mmer @jcorbin would love an implementation / readme review

cc @twolfson `exec-callback` is being shelfed for now, would love to move your "open source best practices" feedback to this PR instead of the `exec-callback` PR.
