### PR TITLE
Support assert

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ function withFixtures(dirname, fixtures, lambda, opts) {
     function thunk(task) {
         function onFixtures(err) {
             if (err) {
-                return task(err);
+                return typeof task === 'function' ? 
+                    task(err) : task.end(err);
             }
 
             var thunk = teardownFixtures.bind(null,

--- a/index.js
+++ b/index.js
@@ -33,6 +33,8 @@ function withFixtures(dirname, fixtures, lambda, opts) {
     function thunk(task) {
         function onFixtures(err) {
             if (err) {
+                // task is either a done callback
+                // or an assert object with an end() method
                 return typeof task === 'function' ? 
                     task(err) : task.end(err);
             }

--- a/test/with-fixtures.js
+++ b/test/with-fixtures.js
@@ -92,6 +92,37 @@ test('createFixtures errors bubbles', function (assert) {
     });
 });
 
+test('createFixtures errors bubbles (assert)', function (assert) {
+    var fs = createFs();
+    var counter = 0;
+
+    fs.dir(BAR_PATH);
+
+    var assertLike = {
+        end: function (err) {
+            assert.ok(err);
+
+            assert.equal(counter, 0);
+            assert.equal(err.code, 'EEXIST');
+
+            assert.end();
+        }
+    };
+
+    var thunk = withFixtures(__dirname, {
+        'foo': 'bar',
+        'bar': {
+            'baz': 'foobar'
+        }
+    }, function (callback) {
+        counter++;
+
+        process.nextTick(callback);
+    }, fs);
+
+    thunk(assertLike);
+});
+
 test('teardownFixtures errors bubbles', function (assert) {
     var fs = createFs();
 


### PR DESCRIPTION
The `return cb(err)` path does not support the assert interface.
